### PR TITLE
Bring source code files up to PEP 8 requirements except for `PyPDF4/`.

### DIFF
--- a/Sample_Code/makesimple.py
+++ b/Sample_Code/makesimple.py
@@ -2,7 +2,6 @@
 "Make some simple multipage pdf files."
 
 from __future__ import print_function
-from sys import argv
 
 from reportlab.pdfgen import canvas
 
@@ -21,18 +20,23 @@ def make_pdf_file(output_filename, np):
     c.setStrokeColorRGB(0,0,0)
     c.setFillColorRGB(0,0,0)
     c.setFont("Helvetica", 12 * point)
+
     for pn in range(1, np + 1):
         v = 10 * inch
+
         for subtline in (TEXT % (output_filename, pn, np)).split( '\n' ):
             c.drawString( 1 * inch, v, subtline )
             v -= 12 * point
+
         c.showPage()
     c.save()
 
+
 if __name__ == "__main__":
     nps = [None, 5, 11, 17]
+
     for i, np in enumerate(nps):
         if np:
             filename = "simple%d.pdf" % i
             make_pdf_file(filename, np)
-            print ("Wrote", filename)
+            print("Wrote", filename)

--- a/Scripts/2-up.py
+++ b/Scripts/2-up.py
@@ -1,54 +1,60 @@
-from PyPDF4 import PdfFileWriter, PdfFileReader
 import sys
-import math
+
+from PyPDF4 import PdfFileWriter, PdfFileReader
+
+# TO-DO Decide which one of the two halves below to keep
 
 
 def main():
-    if (len(sys.argv) != 3):
+    if len(sys.argv) != 3:
         print("usage: python 2-up.py input_file output_file")
         sys.exit(1)
-    print ("2-up input " + sys.argv[1])
+
+    print("2-up input " + sys.argv[1])
+
     input1 = PdfFileReader(open(sys.argv[1], "rb"))
     output = PdfFileWriter()
-    for iter in range (0, input1.getNumPages()-1, 2):
+
+    for iter in range(0, input1.getNumPages() - 1, 2):
         lhs = input1.getPage(iter)
         rhs = input1.getPage(iter+1)
-        lhs.mergeTranslatedPage(rhs, lhs.mediaBox.getUpperRight_x(),0, True)
+        lhs.mergeTranslatedPage(rhs, lhs.mediaBox.getUpperRight_x(), 0, True)
         output.addPage(lhs)
-        print (str(iter) + " "),
+        print(str(iter) + " "),
         sys.stdout.flush()
 
     print("writing " + sys.argv[2])
-    outputStream = file(sys.argv[2], "wb")
-    output.write(outputStream)
+    output_stream = open(sys.argv[2], "wb")
+    output.write(output_stream)
     print("done.")
+
 
 if __name__ == "__main__":
     main()
-from PyPDF4 import PdfFileWriter, PdfFileReader
-import sys
-import math
 
 
 def main():
-    if (len(sys.argv) != 3):
+    if len(sys.argv) != 3:
         print("usage: python 2-up.py input_file output_file")
         sys.exit(1)
-    print ("2-up input " + sys.argv[1])
+
+    print("2-up input " + sys.argv[1])
     input1 = PdfFileReader(open(sys.argv[1], "rb"))
     output = PdfFileWriter()
-    for iter in range (0, input1.getNumPages()-1, 2):
-        lhs = input1.getPage(iter)
-        rhs = input1.getPage(iter+1)
-        lhs.mergeTranslatedPage(rhs, lhs.mediaBox.getUpperRight_x(),0, True)
+
+    for i in range (0, input1.getNumPages()-1, 2):
+        lhs = input1.getPage(i)
+        rhs = input1.getPage(i + 1)
+        lhs.mergeTranslatedPage(rhs, lhs.mediaBox.getUpperRight_x(), 0, True)
         output.addPage(lhs)
-        print (str(iter) + " "),
+        print (str(i) + " "),
         sys.stdout.flush()
 
     print("writing " + sys.argv[2])
-    outputStream = open(sys.argv[2], "wb")
-    output.write(outputStream)
+    output_stream = open(sys.argv[2], "wb")
+    output.write(output_stream)
     print("done.")
+
 
 if __name__ == "__main__":
     main()

--- a/Scripts/pdf-image-extractor.py
+++ b/Scripts/pdf-image-extractor.py
@@ -1,15 +1,15 @@
-'''
+"""
 Extract images from PDF without resampling or altering.
 
 Adapted from work by Sylvain Pelissier
 http://stackoverflow.com/questions/2693820/extract-images-from-pdf-without-resampling-in-python
-'''
+"""
 
 import sys
 import PyPDF4
 from PIL import Image
 
-if (len(sys.argv) != 2):
+if len(sys.argv) != 2:
     print("\nUsage: python {} input_file\n".format(sys.argv[0]))
     sys.exit(1)
 

--- a/Tests/tests.py
+++ b/Tests/tests.py
@@ -1,10 +1,9 @@
+import binascii
 import os
 import sys
 import unittest
-import binascii
 
 from PyPDF4 import PdfFileReader, PdfFileWriter
-
 
 # Configure path environment
 TESTS_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -18,48 +17,64 @@ class PdfReaderTestCases(unittest.TestCase):
 
     def test_PdfReaderFileLoad(self):
         '''
-        Test loading and parsing of a file. Extract text of the file and compare to expected
-        textual output. Expected outcome: file loads, text matches expected.
+        Test loading and parsing of a file. Extract text of the file and
+        compare to expected textual output. Expected outcome: file loads, text
+        matches expected.
         '''
 
-        with open(os.path.join(RESOURCE_ROOT, 'crazyones.pdf'), 'rb') as inputfile:
+        with open(
+                os.path.join(RESOURCE_ROOT, 'crazyones.pdf'), 'rb'
+        ) as inputfile:
             # Load PDF file from file
             ipdf = PdfFileReader(inputfile)
             ipdf_p1 = ipdf.getPage(0)
 
             # Retrieve the text of the PDF
-            with open(os.path.join(RESOURCE_ROOT, 'crazyones.txt'), 'rb') as pdftext_file:
+            with open(
+                    os.path.join(RESOURCE_ROOT, 'crazyones.txt'), 'rb'
+            ) as pdftext_file:
                 pdftext = pdftext_file.read()
 
-            ipdf_p1_text = ipdf_p1.extractText().replace('\n', '').encode('utf-8')
+            ipdf_p1_text = ipdf_p1.extractText(). \
+                replace('\n', '').encode('utf-8')
 
             # Compare the text of the PDF to a known source
-            self.assertEqual(ipdf_p1_text, pdftext,
-                msg='PDF extracted text differs from expected value.\n\nExpected:\n\n%r\n\nExtracted:\n\n%r\n\n'
-                    % (pdftext, ipdf_p1_text))
+            self.assertEqual(
+                ipdf_p1_text, pdftext,
+                msg='PDF extracted text differs from expected value.'
+                    '\n\nExpected:\n\n%r\n\nExtracted:\n\n%r\n\n'
+                    % (pdftext, ipdf_p1_text)
+            )
 
     def test_PdfReaderJpegImage(self):
         '''
-        Test loading and parsing of a file. Extract the image of the file and compare to expected
-        textual output. Expected outcome: file loads, image matches expected.
+        Test loading and parsing of a file. Extract the image of the file and
+        compare to expected textual output. Expected outcome: file loads, image
+        matches expected.
         '''
 
         with open(os.path.join(RESOURCE_ROOT, 'jpeg.pdf'), 'rb') as inputfile:
             # Load PDF file from file
             ipdf = PdfFileReader(inputfile)
-        
+
             # Retrieve the text of the image
-            with open(os.path.join(RESOURCE_ROOT, 'jpeg.txt'), 'r') as pdftext_file:
+            with open(
+                    os.path.join(RESOURCE_ROOT, 'jpeg.txt'), 'r'
+            ) as pdftext_file:
                 imagetext = pdftext_file.read()
-                
-            ipdf_p0 = ipdf.getPage(0)    
+
+            ipdf_p0 = ipdf.getPage(0)
             xObject = ipdf_p0['/Resources']['/XObject'].getObject()
             data = xObject['/Im4'].getData()
-    
+
             # Compare the text of the PDF to a known source
-            self.assertEqual(binascii.hexlify(data).decode(), imagetext, 
-                             msg='PDF extracted image differs from expected value.\n\nExpected:\n\n%r\n\nExtracted:\n\n%r\n\n' 
-                             % (imagetext, binascii.hexlify(data).decode()))
+            self.assertEqual(
+                binascii.hexlify(data).decode(), imagetext,
+                msg='PDF extracted image differs from expected value.'
+                    '\n\nExpected:\n\n%r\n\nExtracted:\n\n%r\n\n'
+                    % (imagetext, binascii.hexlify(data).decode())
+            )
+
 
 class AddJsTestCase(unittest.TestCase):
 
@@ -69,25 +84,47 @@ class AddJsTestCase(unittest.TestCase):
         self.pdf_file_writer.appendPagesFromReader(ipdf)
 
     def test_add(self):
+        self.pdf_file_writer.addJS(
+            "this.print({bUI:true,bSilent:false,bShrinkToFit:true});"
+        )
 
-        self.pdf_file_writer.addJS("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
-
-        self.assertIn('/Names', self.pdf_file_writer._root_object, "addJS should add a name catalog in the root object.")
-        self.assertIn('/JavaScript', self.pdf_file_writer._root_object['/Names'], "addJS should add a JavaScript name tree under the name catalog.")
-        self.assertIn('/OpenAction', self.pdf_file_writer._root_object, "addJS should add an OpenAction to the catalog.")
+        self.assertIn(
+            '/Names', self.pdf_file_writer._root_object,
+            "addJS should add a name catalog in the root object."
+        )
+        self.assertIn(
+            '/JavaScript', self.pdf_file_writer._root_object['/Names'],
+            "addJS should add a JavaScript name tree under the name catalog."
+        )
+        self.assertIn(
+            '/OpenAction', self.pdf_file_writer._root_object,
+            "addJS should add an OpenAction to the catalog."
+        )
 
     def test_overwrite(self):
-
-        self.pdf_file_writer.addJS("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
+        self.pdf_file_writer.addJS(
+            "this.print({bUI:true,bSilent:false,bShrinkToFit:true});"
+        )
         first_js = self.get_javascript_name()
 
-        self.pdf_file_writer.addJS("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
+        self.pdf_file_writer.addJS(
+            "this.print({bUI:true,bSilent:false,bShrinkToFit:true});"
+        )
         second_js = self.get_javascript_name()
 
-        self.assertNotEqual(first_js, second_js, "addJS should overwrite the previous script in the catalog.")
+        self.assertNotEqual(
+            first_js, second_js,
+            "addJS should overwrite the previous script in the catalog."
+        )
 
     def get_javascript_name(self):
         self.assertIn('/Names', self.pdf_file_writer._root_object)
-        self.assertIn('/JavaScript', self.pdf_file_writer._root_object['/Names'])
-        self.assertIn('/Names', self.pdf_file_writer._root_object['/Names']['/JavaScript'])
-        return self.pdf_file_writer._root_object['/Names']['/JavaScript']['/Names'][0]
+        self.assertIn(
+            '/JavaScript', self.pdf_file_writer._root_object['/Names']
+        )
+        self.assertIn(
+            '/Names',
+            self.pdf_file_writer._root_object['/Names']['/JavaScript']
+        )
+        return self.pdf_file_writer. \
+            _root_object['/Names']['/JavaScript']['/Names'][0]


### PR DESCRIPTION
Several style reformattings were added to source code files that were not
following PEP 8 style conventions. The files residing in `PyPDF4/` were
excluded from the process.

The Python Enhancement Proposal 8 specifies a list of stylistic conventions. See [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/) for more. Contributors are motivated to equip with smart IDEs capable of recognizing PEP 8 style violations!