### PR TITLE
Fix tox support and only test supported versions of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,17 @@ Please see http://claird.github.io/PyPDF4/FAQ.html (available in early August).
 ## Tests
 PyPDF4 includes a modest (but growing!) test suite built on the unittest
 framework. All tests are located in the `tests/` folder and are distributed
-among dedicated modules. Tests can be run from the command line using tox:
+among dedicated modules. Tests can be run from the command line using `tox`:
 
 ```
 python -m pip install tox
 python -m tox
+```
+
+or by the more down-to-earth `unittest` module:
+
+```
+python[23] -m unittest discover --start-directory tests/
 ```
 
 ## Contributing


### PR DESCRIPTION
This patch:

* Fixes tox support so that all versions of Python can be tested in one command
* Drops support for Python 2.6, 3.3, and 3.4.
* Adds support for Python 3.6 and 3.7.
* Adds HTML coverage reporting so that it's easy to see what is and is not getting tested.

Note that the unit tests are currently failing on **all** Python versions. I will be working to resolve this in a separate merge request.

Closes #1
Fixes #36