### PR TITLE
Ignore the auto-generated `dist/` subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 *.pyc
 *.sw[op]
 .DS_Store


### PR DESCRIPTION
Ignoring this file will make things easier when creating a source distribution file using the `python setup.py sdist` command.

Fixes #45