### PR TITLE
Test ASCII85 more thoroughly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .tox
 build
 .idea/*
+htmlcov/
+.coverage

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Please see http://claird.github.io/PyPDF4/FAQ.html (available in early August).
 ## Tests
 PyPDF4 includes a modest (but growing!) test suite built on the unittest
 framework. All tests are located in the `tests/` folder and are distributed
-among dedicated modules. Tests can be run from the command line by:
+among dedicated modules. Tests can be run from the command line using tox:
 
 ```
-python2 -m unittest discover --start-directory tests/
-python3 -m unittest discover --start-directory tests/
+python -m pip install tox
+python -m tox
 ```
 
 ## Contributing

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -581,7 +581,6 @@ class ASCII85Codec(object):
         :return: bytes for Python 3, str for Python 2.
         """
         if sys.version_info[0] < 3:
-            # TO-DO Add check for missing '~>' EOD marker.
             group_index = b = 0
             out = bytearray()
 
@@ -602,6 +601,10 @@ class ASCII85Codec(object):
             # Strip leading '<~' characters, if present.
             if data.startswith("<~"):
                 data = data[2:]
+
+            # Ensure that the data ends with '~>' characters.
+            if not data.endswith("~>"):
+                raise ValueError("Ascii85 encoded byte sequences must end with '~>'")
 
             for index, c in enumerate(data):
                 # Ignore whitespace characters.

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -585,6 +585,12 @@ class ASCII85Codec(object):
             group_index = b = 0
             out = bytearray()
 
+            if isinstance(data, unicode):
+                try:
+                    data = data.encode("ascii")
+                except UnicodeEncodeError:
+                    raise ValueError('unicode argument should contain only ASCII characters')
+
             if isinstance(data, bytes):
                 data = data.decode("LATIN1")
             elif not isinstance(data, str):

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -599,6 +599,10 @@ class ASCII85Codec(object):
                     data.__class__.__name__
                 )
 
+            # Strip leading '<~' characters, if present.
+            if data.startswith("<~"):
+                data = data[2:]
+
             for index, c in enumerate(data):
                 byte = ord(c)
 

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -568,7 +568,7 @@ class ASCII85Codec(object):
                 # resulting group of 5.» - ISO 32000 (2008), sec. 7.4.3
                 result += ascii85[:min(5, groupWidth + 1)]
 
-            return (result + "~>").encode("LATIN1")
+            return ("<~" + result + "~>").encode("LATIN1")
         else:
             return base64.a85encode(data, adobe=True)
 

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -616,7 +616,8 @@ class ASCII85Codec(object):
                         group_index = b = 0
                 # 122 == ord('z')
                 elif byte == 122:
-                    assert group_index == 0
+                    if group_index:
+                        raise ValueError('z inside Ascii85 5-tuple')
                     out.extend(b"\x00\x00\x00\x00")
                 # 126 == ord('~') and 62 == ord('>')
                 elif byte == 126 and data[index + 1] == '>':

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -604,6 +604,9 @@ class ASCII85Codec(object):
                 data = data[2:]
 
             for index, c in enumerate(data):
+                # Ignore whitespace characters.
+                if not c.strip(' \n\r\t\v'):
+                    continue
                 byte = ord(c)
 
                 # 33 == ord('!') and 117 == ord('u')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -12,6 +12,8 @@ from math import floor, log
 
 from os.path import abspath, dirname, join
 
+import pytest
+
 from pypdf.filters import FlateCodec, ASCIIHexCodec, ASCII85Codec,\
     LZWCodec, DCTCodec, CCITTFaxCodec, decodeStreamData
 from pypdf.generic import EncodedStreamObject, IndirectObject
@@ -21,6 +23,21 @@ from tests.utils import intToBitstring
 
 TESTS_ROOT = abspath(dirname(__file__))
 TEST_DATA_ROOT = join(TESTS_ROOT, "fixture_data")
+
+
+# Establish bytes/str/unicode types.
+try:
+    unicode
+except NameError:
+    # Python 3
+    bytes_type = bytes
+    str_type = str
+    unicode_type = str
+else:
+    # Python 2
+    bytes_type = bytes
+    str_type = str
+    unicode_type = unicode
 
 
 class FlateCodecTestCase(unittest.TestCase):
@@ -346,5 +363,46 @@ class DecodeStreamDataTestCase(unittest.TestCase):
                     )
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize(
+    "data, expected_value, exception",
+    (
+        (b'<~~>', b'', None),  # Empty input
+        (b'<~@:E^~>', b'abc', None),  # Basic decoding
+        (u'<~@:E^~>', b'abc', None),  # Handle a str (or unicode) object
+        (b'<~@: E^~>', b'abc', None),  # Ignore whitespace
+        (b'<~z~>', b'\x00\x00\x00\x00', None),  # Handle 'z'
+        (b'~>', b'', None),  # No initial '<~'
+        (b'@:E^~>', b'abc', None),  # No initial '<~'
+
+        (b'', None, ValueError),  # Choke on missing '~>'
+        (b'>', None, ValueError),  # Choke on missing '~>'
+        (b'<~<~~>', None, ValueError),  # Don't double-skip '<~'
+        (b'<~~~>', None, ValueError),  # Choke on bare '~'
+        (b'<~aazaa~>', None, ValueError),  # Choke on mid-group 'z'
+        (u'<~\x80~>', None, ValueError),  # Choke on non-ASCII characters
+    )
+)
+def test_ascii85_decode(data, expected_value, exception):
+    if exception:
+        with pytest.raises(exception):
+            ASCII85Codec.decode(data)
+    else:
+        value = ASCII85Codec.decode(data)
+        assert value == expected_value
+        assert isinstance(value, bytes_type)
+
+
+@pytest.mark.parametrize(
+    "data, expected_value",
+    (
+        (b'', b'<~~>'),
+        (b'abc', b'<~@:E^~>'),
+        (b'\x00', b'<~!!~>'),
+        (b'\xff', b'<~rr~>'),
+        (b'\x00\x00\x00\x00', b'<~z~>'),
+    )
+)
+def test_ascii85_encode(data, expected_value):
+    value = ASCII85Codec.encode(data)
+    assert value == expected_value
+    assert isinstance(value, bytes_type)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -162,13 +162,13 @@ class ASCII85CodecTestCase(unittest.TestCase):
         """
         e, d = ASCII85Codec.encode, ASCII85Codec.decode
         inputs = [
-            string.ascii_lowercase, string.ascii_uppercase,
-            string.ascii_letters, string.whitespace,
-            "\x00\x00\x00\x00", 2 * "\x00\x00\x00\x00",
+            string.ascii_lowercase.encode('ascii'), string.ascii_uppercase.encode('ascii'),
+            string.ascii_letters.encode('ascii'), string.whitespace.encode('ascii'),
+            b"\x00\x00\x00\x00", 2 * b"\x00\x00\x00\x00",
         ]
 
         for filename in ("TheHappyPrince.txt", ):
-            with open(join(TEST_DATA_ROOT, filename)) as infile:
+            with open(join(TEST_DATA_ROOT, filename), 'rb') as infile:
                 inputs.append(infile.read())
 
         for i in inputs:
@@ -179,8 +179,6 @@ class ASCII85CodecTestCase(unittest.TestCase):
                 exp = i
 
             self.assertEqual(exp, d(e(i)))
-            # Tests with input in bytes form
-            self.assertEqual(exp, d(e(i.encode("LATIN1"))))
 
     def testWithOverflow(self):
         inputs = (
@@ -204,19 +202,19 @@ class ASCII85CodecTestCase(unittest.TestCase):
         by the character with code 122 (z) instead of by five exclamation
         points (!!!!!).»
         """
-        inputs = ("z", "zz", "zzz")
+        inputs = (b"z~>", b"zz~>", b"zzz~>")
         expOutputs = (
             b"\x00\x00\x00\x00", b"\x00\x00\x00\x00" * 2,
             b"\x00\x00\x00\x00" * 3,
         )
 
         self.assertEqual(
-            ASCII85Codec.decode("!!!!!"), ASCII85Codec.decode("z")
+            ASCII85Codec.decode(b"!!!!!~>"), ASCII85Codec.decode(b"z~>")
         )
 
         for o, i in zip(expOutputs, inputs):
             self.assertEqual(
-                o, ASCII85Codec.decode(i + "~>")
+                o, ASCII85Codec.decode(i)
             )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,29 @@
 [tox]
 envlist =
-	py26, py27, py33, py34, py35
+    clean,
+    py27, py35, py36, py37,
+    report
 
 [testenv]
-commands = python -m unittest Tests.tests
+commands = pytest --cov --cov-append tests/
+deps =
+    pytest
+    pytest-cov
 
-[testenv:py26]
-basepython = python2.6
+[testenv:clean]
+commands = python -m coverage erase
 
 [testenv:py27]
 basepython = python2.7
 
-[testenv:py33]
-basepython = python3.3
-
-[testenv:py34]
-basepython = python3.4
-
 [testenv:py35]
 basepython = python3.5
+
+[testenv:py36]
+basepython = python3.6
+
+[testenv:py37]
+basepython = python3.7
+
+[testenv:report]
+commands = python -m coverage html


### PR DESCRIPTION
*NOTE: This includes commit bc672fb, which is already the subject of PR #37. I suggest merging #37 first before reviewing this PR.*

The ASCII85 implementation needed some additional testing and bug fixes to bring its behavior in line with Python 3's builtin ASCII85 encoder and decoder.

This patch makes PyPDF4 call Python 3's ASCII85 encoder and decoder when possible. It also fixes the existing ASCII85 encoder/decoder code so that the code behaves nearly identically in Python 2.

Finally, it fixes the bugs I reported in #47, #48, #49, #50, #51, and #52.