### PR TITLE
fix PDF writer bug when encountering free object

### DIFF
--- a/pypdf/pdf.py
+++ b/pypdf/pdf.py
@@ -672,7 +672,7 @@ class PdfFileWriter(object):
                         self._objects[idnum-1] = newobj
 
                         return newobj_ido
-                    except ValueError:
+                    except (ValueError, PyPdfError):
                         # Unable to resolve the Object, returning NullObject
                         # instead.
                         warnings.warn(


### PR DESCRIPTION
When editing an existing PDF, occasionally the PDF contains a "free" `IndirectObject` that refers to nothing (correct me if I'm conceptually wrong). In this situation the reader will raise a `PdfReadError`:
```
            warnings.warn(
                "Object %d %d not defined." %
                (ref.idnum, ref.generation), PdfReadWarning
            )
            raise PdfReadError(
                "Could not find object (%d, %d)" % (ref.idnum, ref.generation)
            )
```
This exception will be passed to `writer._sweepIndirectReferences()`. However the `except` statement doesn't capture this exception, but only captures `ValueError`, which is not a base class of `PdfReadError`:
```
                     except ValueError:
                        # Unable to resolve the Object, returning NullObject
                        # instead.
                        warnings.warn(
                            "Unable to resolve [{}: {}], returning NullObject "
                            "instead".format(data.__class__.__name__, data)
                        )
                        return NullObject()
```
This will crash the script.

Hence this pull request updates this line to handle the PdfReadError exception. To be safer, it's modified to capture its base class, `PyPdfError`:
```
                     except (ValueError, PyPdfError):
                     ...
```