### PR TITLE
Fix DictionaryObject.__init__()

### DIFF
--- a/pypdf/generic.py
+++ b/pypdf/generic.py
@@ -734,7 +734,7 @@ class DictionaryObject(dict, PdfObject):
 
 class TreeObject(DictionaryObject):
     def __init__(self):
-        DictionaryObject.__init__()
+        DictionaryObject.__init__(self)
 
     def hasChildren(self):
         return '/First' in self


### PR DESCRIPTION
Adding bookmarks with PdfFileWriter.addBookmark crashes the program and provides the following error.

```
Traceback (most recent call last):
  File "basic_features.py", line 110, in <module>
    main()
  File "basic_features.py", line 73, in main
    writer.addBookmark("test", 1)
  File "PyPDF4/pypdf/pdf.py", line 824, in addBookmark
    outlineRef = self.getOutlineRoot()
  File "PyPDF4/pypdf/pdf.py", line 703, in getOutlineRoot
    outline = TreeObject()
  File "PyPDF4/pypdf/generic.py", line 737, in __init__
    DictionaryObject.__init__()
TypeError: descriptor '__init__' of 'dict' object needs an argument
```