### PR TITLE
Escape addJS js code by using createStringObject

### DIFF
--- a/pypdf/pdf.py
+++ b/pypdf/pdf.py
@@ -282,7 +282,7 @@ class PdfFileWriter(object):
         js.update({
             NameObject("/Type"): NameObject("/Action"),
             NameObject("/S"): NameObject("/JavaScript"),
-            NameObject("/JS"): NameObject("(%s)" % javascript)
+            NameObject("/JS"): createStringObject(javascript)
         })
         js_indirect_object = self._addObject(js)
 


### PR DESCRIPTION
`PdfFileWriter.addJS` used `NameObject('(%s)' % code)` instead of using `createStringObject`,
which means the code wasn't escaped.

Fixes #69 