### PR TITLE
Fixed addJS running twice

### DIFF
--- a/pypdf/pdf.py
+++ b/pypdf/pdf.py
@@ -303,7 +303,7 @@ class PdfFileWriter(object):
         self._addObject(js_name_tree)
 
         self._rootObject.update({
-            NameObject("/OpenAction"): js_indirect_object,
+            NameObject("/JavaScript"): js_indirect_object,
             NameObject("/Names"): js_name_tree
         })
 

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -449,8 +449,8 @@ class AddJsTestCase(unittest.TestCase):
             "addJS should add a JavaScript name tree under the name catalog."
         )
         self.assertIn(
-            '/OpenAction', self.writer._rootObject,
-            "addJS should add an OpenAction to the catalog."
+            '/JavaScript', self.writer._rootObject,
+            "addJS should add a JavaScript action to the catalog."
         )
 
     def testOverwrite(self):


### PR DESCRIPTION
Fixes #70

This implements the [fix suggested](https://github.com/mstamy2/PyPDF2/issues/482#issuecomment-482403366) in mstamy2/PyPDF2#482 by @youssef-jaber - replacing `/OpenAction` with `/JavaScript`.

I'm not actually sure what this does, so I'm open to suggestions if this isn't a good fix.