### PR TITLE
Fix  'ModuleNotFoundError: No module named 'pypdf'' when running samp…

### DIFF
--- a/samplecode/MergingComments.py
+++ b/samplecode/MergingComments.py
@@ -11,7 +11,7 @@
 import os
 import sys
 
-import pypdf as PDF
+import PyPDF4 as PDF
 
 if sys.argv[0].upper().find("PYTHON.EXE") >= 0:
     del sys.argv[0]

--- a/samplecode/PDFComments2XL.py
+++ b/samplecode/PDFComments2XL.py
@@ -17,7 +17,7 @@ import sys
 from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 
-import pypdf as PDF
+import PyPDF4 as PDF
 
 locale.setlocale(locale.LC_ALL, locale.getdefaultlocale()[0])
 

--- a/samplecode/basic_features.py
+++ b/samplecode/basic_features.py
@@ -8,7 +8,7 @@ from os import pardir
 from os.path import abspath, basename, dirname, join
 from sys import argv, path, stderr
 
-from PyPDF4.pdf import PdfFileReader, PdfFileWriter
+from PyPDF4 import PdfFileReader, PdfFileWriter
 
 SAMPLE_CODE_ROOT = dirname(__file__)
 SAMPLE_PDF_ROOT = join(SAMPLE_CODE_ROOT, "pdfsamples")

--- a/samplecode/basic_features.py
+++ b/samplecode/basic_features.py
@@ -8,7 +8,7 @@ from os import pardir
 from os.path import abspath, basename, dirname, join
 from sys import argv, path, stderr
 
-from pypdf.pdf import PdfFileReader, PdfFileWriter
+from PyPDF4.pdf import PdfFileReader, PdfFileWriter
 
 SAMPLE_CODE_ROOT = dirname(__file__)
 SAMPLE_PDF_ROOT = join(SAMPLE_CODE_ROOT, "pdfsamples")

--- a/samplecode/basic_merging.py
+++ b/samplecode/basic_merging.py
@@ -8,7 +8,7 @@ from os import pardir
 from os.path import abspath, dirname, join
 from sys import argv, path
 
-from PyPDF44import PdfFileMerger, PdfFileReader
+from PyPDF4 import PdfFileMerger, PdfFileReader
 
 SAMPLE_CODE_ROOT = dirname(__file__)
 SAMPLE_PDF_ROOT = join(SAMPLE_CODE_ROOT, "pdfsamples")

--- a/samplecode/basic_merging.py
+++ b/samplecode/basic_merging.py
@@ -8,7 +8,7 @@ from os import pardir
 from os.path import abspath, dirname, join
 from sys import argv, path
 
-from pypdf import PdfFileMerger, PdfFileReader
+from PyPDF44import PdfFileMerger, PdfFileReader
 
 SAMPLE_CODE_ROOT = dirname(__file__)
 SAMPLE_PDF_ROOT = join(SAMPLE_CODE_ROOT, "pdfsamples")


### PR DESCRIPTION
Was taking this module for a trial run and found the sample code wasn't working.  PR to resolve the error.

### Repro:
- run the recommend command from the repo root
  `python3 ./samplecode/basic_features.py`
- get the following error:
```
 > python  .\samplecode\basic_features.py
Traceback (most recent call last):
  File ".\samplecode\basic_features.py", line 11, in <module>
    from pypdf.pdf import PdfFileReader, PdfFileWriter
ModuleNotFoundError: No module named 'pypdf'
```