### PR TITLE
Change ContentStream.__parseContentStream so that readObject is called with self.pdf instead of None; solves issues when pdf.strict is checked in readObject methods.

### DIFF
--- a/pypdf/generic.py
+++ b/pypdf/generic.py
@@ -1024,7 +1024,7 @@ class ContentStream(DecodedStreamObject):
                 while peek not in (b_("\r"), b_("\n")):
                     peek = stream.read(1)
             else:
-                operands.append(readObject(stream, None))
+                operands.append(readObject(stream, self.pdf))
 
     def _readInlineImage(self, stream):
         # Begin reading just after the "BI" - begin image


### PR DESCRIPTION
Workaround issue https://github.com/claird/PyPDF4/issues/81