### PR TITLE
Update filters.py according to pypdf2 (issue #422)

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -43,7 +43,7 @@ try:
     import zlib
 
     def decompress(data):
-        return zlib.decompress(data)
+        return zlib.decompressobj().decompress(data)
 
     def compress(data):
         return zlib.compress(data)


### PR DESCRIPTION
There are some errors in some cases during zlib decompression (eg. I have a PDF with overlay of text, it is the same issue which is documented here https://github.com/mstamy2/PyPDF2/issues/422 ). With this change, the decompression is working without errors.